### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -17,6 +17,13 @@ import (
 
 )
 
+func sanitizeToken(token string) string {
+	if len(token) > 10 {
+		return token[:10] + "..."
+	}
+	return token
+}
+
 type Configuration struct {
 	Host 		string	`json:"host"`
 	Port 		int		`json:"port"`
@@ -660,7 +667,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token (sanitized): %s", sanitizeToken(authz))
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)


### PR DESCRIPTION
Potential fix for [https://github.com/dmd-demo/ghas_demo/security/code-scanning/4](https://github.com/dmd-demo/ghas_demo/security/code-scanning/4)

To fix the issue, we should avoid logging the full `Authorization` header or its bearer token. Instead, we can log a sanitized or obfuscated version of the token (e.g., only the first few characters) or omit it entirely. This ensures that sensitive information is not exposed in logs while still providing enough context for debugging purposes.

Specifically:
1. Replace the logging of the full `authz` value on line 663 with a sanitized version.
2. Ensure that no other sensitive data is logged in clear text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
