### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -17,6 +17,13 @@ import (
 
 )
 
+func sanitizeToken(token string) string {
+	if len(token) <= 10 {
+		return "****"
+	}
+	return fmt.Sprintf("%s****%s", token[:4], token[len(token)-4:])
+}
+
 type Configuration struct {
 	Host 		string	`json:"host"`
 	Port 		int		`json:"port"`
@@ -641,7 +648,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token %s", sanitizeToken(tokenString))
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {


### PR DESCRIPTION
Potential fix for [https://github.com/dmd-demo/ghas_demo/security/code-scanning/3](https://github.com/dmd-demo/ghas_demo/security/code-scanning/3)

To fix the issue, we should avoid logging the sensitive `tokenString` in plaintext. Instead, we can log a sanitized or obfuscated version of the token (e.g., by masking most of it) or omit it entirely. This ensures that sensitive information is not exposed in the logs while still providing enough context for debugging purposes.

Specifically:
1. Replace the logging of the full `tokenString` on line 644 with a sanitized version (e.g., showing only the first and last few characters).
2. Ensure that no other sensitive data is logged in plaintext.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
